### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/alexcamposve0675/97be82cd-bbbd-43da-8a95-ad405f8efc4c/0cefdb5c-7d91-42b3-a819-743fadf9ab90/_apis/work/boardbadge/2d3795cd-b988-4839-a99e-f8111c2a8906)](https://dev.azure.com/alexcamposve0675/97be82cd-bbbd-43da-8a95-ad405f8efc4c/_boards/board/t/0cefdb5c-7d91-42b3-a819-743fadf9ab90/Microsoft.RequirementCategory)
 # riveraexpress
  ventas


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#8. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.